### PR TITLE
Use print_string for Windows compatibility

### DIFF
--- a/which_result.ml
+++ b/which_result.ml
@@ -8,4 +8,4 @@ let () =
     else
       "result-as-alias.ml"
   in
-  print_endline file
+  print_string file


### PR DESCRIPTION
Hi,

Thanks for this library. This makes it way easier to follow compiler changes.

I tried to use it under Windows (MinGW compiler + Cygwin for make, bash, etc), but the build fails the
following error:

```
cp `ocaml which_result.ml` result.ml
cp: cannot stat ‘result-as-newtype.ml\r’: No such file or directory
```

The issue is that `print_endline` will append `\r\n`, and the backticks will
remove only `\n`.

I'm not sure whose fault it is, but the problem can be fixed by replacing
`print_endline` by `print_string`, which also works on Linux.

What do you think?

:sparkles: Thanks! :sparkles: 
