### PR TITLE
Added target to fix make errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ result.ml: which_result.ml
 	cp `ocaml which_result.ml` result.ml
 
 .PHONY: byte
-byte: result.ml
+byte result.cma: result.ml
 	ocamlc -c result.ml
 	ocamlc -a -o result.cma result.cmo
 


### PR DESCRIPTION
When compiling this under pkgsrc, I got error messages (both with BSD and GNU make) about not knowing how to make result.cma, so I added that target manually. With this patch, everything compiles normally.
