### PR TITLE
Include Stdlib.Result on OCaml >= 4.08.0

### DIFF
--- a/result-as-alias-4.08.ml
+++ b/result-as-alias-4.08.ml
@@ -1,0 +1,2 @@
+include Stdlib.Result
+type ('a, 'b) result = ('a, 'b) Stdlib.Result.t

--- a/result-as-alias.ml
+++ b/result-as-alias.ml
@@ -1,1 +1,2 @@
 type nonrec ('a, 'b) result = ('a, 'b) result = Ok of 'a | Error of 'b
+type ('a, 'b) t = ('a, 'b) result

--- a/result-as-newtype.ml
+++ b/result-as-newtype.ml
@@ -1,1 +1,2 @@
 type ('a, 'b) result = Ok of 'a | Error of 'b
+type ('a, 'b) t = ('a, 'b) result

--- a/which_result.ml
+++ b/which_result.ml
@@ -6,6 +6,9 @@ let () =
     if version < (4, 03) then
       "result-as-newtype.ml"
     else
-      "result-as-alias.ml"
+      if version < (4, 08) then
+        "result-as-alias.ml"
+      else
+        "result-as-alias-4.08.ml"
   in
   print_string file


### PR DESCRIPTION
...also make sure `Result.t` is defined on all versions.

Fixes #8.

cc @TypesLogicsCats @hcarty @hongchangwu